### PR TITLE
DrawText created an unnecessary array

### DIFF
--- a/EngineContents/gfx.cs
+++ b/EngineContents/gfx.cs
@@ -76,12 +76,9 @@ namespace Consyl_Engine.EngineContents
         }
         public static void DrawText(int x, int y, string text) // Draws text in a position on screen
         {
-            char[] charArray = new char[text.Length];
-            charArray = text.ToCharArray();
-
-            for (int i = 0; i < text.Length; i++)
+	        for (int i = 0; i < text.Length; i++)
             {
-                DrawPixel(x + i, y, charArray[i]);
+                DrawPixel(x + i, y, text[i]);
             }
         }
 


### PR DESCRIPTION
The string can be iterated over directly. Also, when you use ToCharArray, you dont need to first allocate the array with new, ToCharArray returns the pointer to the array directly:
char[] charArray = text.ToCharArray();
if you needed to do that.